### PR TITLE
feat: added assert for different Size constructors

### DIFF
--- a/lib/src/widgets/verification_code_field.dart
+++ b/lib/src/widgets/verification_code_field.dart
@@ -17,7 +17,9 @@ class VerificationCodeField extends HookWidget {
     this.spaceBetween = 16,
     RegExp? matchingPattern,
     super.key,
-  }) : assert(length > 0, 'Length must be positive') {
+  })  : assert(length > 0, 'Length must be positive'),
+        assert(size.height != double.infinity && size.width != double.infinity,
+            'The height and width of the Size must be finite.') {
     pattern = matchingPattern ?? RegExp(r'^\d+$');
   }
 


### PR DESCRIPTION
I tried adding a default values and tested some options, but my suggestion is to leave it as an assertion

for:
Size.fromWidth
Size.fromHeight
Size.infinite